### PR TITLE
Fix Trivy and SonarCloud errors in CI/CD pipeline

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -21,12 +21,12 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.1.7
       with:
         fetch-depth: 0
 
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v4.2.1
       with:
         java-version: ${{ env.JAVA_VERSION }}
         distribution: 'temurin'
@@ -36,7 +36,7 @@ jobs:
       run: ./mvnw clean test
 
     - name: SonarCloud Scan
-      uses: SonarSource/sonarcloud-github-action@master
+      uses: SonarSource/sonarcloud-github-action@v2.2.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -48,14 +48,14 @@ jobs:
       run: docker build -t bankapp:security-scan .
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@0.24.0
       with:
         image-ref: 'bankapp:security-scan'
         format: 'sarif'
         output: 'trivy-results.sarif'
 
     - name: Upload Trivy scan results
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v3.25.15
       if: always()
       with:
         sarif_file: 'trivy-results.sarif'
@@ -68,17 +68,17 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.1.7
 
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v4.2.1
       with:
         java-version: ${{ env.JAVA_VERSION }}
         distribution: 'temurin'
         cache: maven
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v4.0.2
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -97,7 +97,7 @@ jobs:
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v2
+      uses: aws-actions/amazon-ecr-login@v2.2.0
 
     - name: Build and push Docker image
       id: build-image

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN ls
 
 ENV APP_HOME=/usr/src/app
 
-COPY app/*.jar $APP_HOME/app.jar
+COPY target/*.jar $APP_HOME/app.jar
 
 WORKDIR $APP_HOME
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 		<jacoco.version>0.8.7</jacoco.version>
    		<sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
     		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
-    		<sonar.jacoco.reportPath>${project.basedir}/../target/jacoco.exec</sonar.jacoco.reportPath>
+		<sonar.jacoco.reportPath>${project.build.directory}/jacoco.exec</sonar.jacoco.reportPath>
     		<sonar.language>java</sonar.language>
 	</properties>
 	<dependencies>
@@ -62,11 +62,6 @@
 			<version>8.0.33</version>
 			<scope>runtime</scope>
 		</dependency>
-		<dependency>
-    <groupId>org.jacoco</groupId> 
-    <artifactId>jacoco-maven-plugin</artifactId>
-    <version>0.8.7</version>
-</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,5 @@
 sonar.projectKey=DevOps-Colony_Github-Actions-Project
 sonar.organization=devops-colony
-sonar.java.binaries=.
 sonar.projectName=Github-Actions-Project
 sonar.projectVersion=1.0
 


### PR DESCRIPTION
This commit addresses two issues in the CI/CD pipeline:
1.  The Trivy scan was failing because the Docker build was unable to find the application JAR file. This has been fixed by correcting the path in the `Dockerfile`.
2.  The SonarCloud quality gate was failing due to an incorrect configuration for the code coverage report. This has been fixed by correcting the path in the `pom.xml` and cleaning up the `sonar-project.properties` file.

In addition, the GitHub Actions in the `deploy-staging.yml` workflow have been pinned to specific versions to improve stability.